### PR TITLE
Replace compile-only test with a runtime test

### DIFF
--- a/cetlib_except/exception.h
+++ b/cetlib_except/exception.h
@@ -75,7 +75,8 @@ namespace cet::detail {
     std::is_base_of_v<cet::exception, std::remove_reference_t<T>>;
 
   template <typename T>
-  concept Streamable = requires(std::ostream os, T value) { os << value; };
+  concept Streamable =
+    requires(std::ostream& os, T const& value) { os << value; };
 } // cet::detail
 
 // ======================================================================

--- a/cetlib_except/test/CMakeLists.txt
+++ b/cetlib_except/test/CMakeLists.txt
@@ -30,4 +30,4 @@ foreach(test IN LISTS catch2_tests)
     LIBRARIES PRIVATE cetlib_except::Catch2Matchers Catch2::Catch2)
 endforeach()
 
-cet_test(exception_bad_append_t COMPILE_ONLY TEST_PROPERTIES WILL_FAIL TRUE)
+cet_test(exception_bad_append_t USE_CATCH2_MAIN)

--- a/cetlib_except/test/exception_bad_append_t.cc
+++ b/cetlib_except/test/exception_bad_append_t.cc
@@ -1,13 +1,27 @@
+#include <catch2/catch_test_macros.hpp>
+
 #include "cetlib_except/exception.h"
-using cet::exception;
+
+#include <concepts>
+#include <ostream>
 
 namespace {
+  struct Streamable {
+    int i;
+  };
+  std::ostream&
+  operator<<(std::ostream& os, Streamable const& s)
+  {
+    return os << s.i;
+  }
   struct UnStreamable {};
+  template <typename T>
+  concept can_append_to_exception =
+    requires(cet::exception&& e, T const& t) { e.append(t); };
 }
 
-int
-main()
+TEST_CASE("Ensure streamable exception append")
 {
-  exception e("Hello");
-  e << UnStreamable{};
+  REQUIRE(can_append_to_exception<Streamable>);
+  REQUIRE_FALSE(can_append_to_exception<UnStreamable>);
 }


### PR DESCRIPTION
- Improve `requires` expression signature for detail::Streamable
- Replace the compile-time append-ability test with a runtime test
